### PR TITLE
Bug duplicate projects

### DIFF
--- a/__tests__/projects.js
+++ b/__tests__/projects.js
@@ -66,7 +66,6 @@ describe('RepositoryProjectsManager.sync() posts requests to the API', () => {
 });
 
 describe('when the API initially returns suspiciously few projects', () => {
-
   describe('when the API then returns a sane number of projects on second retry', () => {
     let rpm;
 
@@ -176,7 +175,7 @@ describe('when the API initially returns suspiciously few projects', () => {
       rpm = new RepositoryProjectsManager({ apiWrapper, ownerName: 'acme', repositoryName: 'example-repository' });
     });
 
-    test('when four projects are missing', async () => {
+    test('all projects are present and creating a new project was not necessary', async () => {
       const titles = [
         'layer-200/module-1',
         'layer-100/module-2',
@@ -298,7 +297,7 @@ describe('when the API initially returns suspiciously few projects', () => {
       rpm = new RepositoryProjectsManager({ apiWrapper, ownerName: 'acme', repositoryName: 'example-repository' });
     });
 
-    test('when four projects are missing', async () => {
+    test('all projects are present and four of which were created new', async () => {
       const titles = [
         'layer-200/module-1',
         'layer-100/module-2',

--- a/__tests__/projects.js
+++ b/__tests__/projects.js
@@ -64,3 +64,252 @@ describe('RepositoryProjectsManager.sync() posts requests to the API', () => {
     expect(outputTitles).toEqual(titles);
   });
 });
+
+describe('when the API initially returns suspiciously few projects', () => {
+
+  describe('when the API then returns a sane number of projects on second retry', () => {
+    let rpm;
+
+    beforeEach(() => {
+      const apiWrapper = new ApiWrapper({ octokit: null });
+
+      jest.spyOn(apiWrapper, 'fetchOrganiztion')
+        .mockImplementation(() => ({
+          organization: {
+            id: 'O_0000000001',
+            name: 'Babbel Sandbox',
+          },
+        }));
+
+      // API returns three projects fewer than actually exist
+      jest.spyOn(apiWrapper, 'fetchRepository')
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+            ],
+          },
+        }))
+
+        // on first retry, API agian returns three projects fewer than expected
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-100/module-1',
+              },
+            ],
+          },
+        }))
+
+        // on second retry, API returns all projects
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+              {
+                id: 'PVT_000000000000002',
+                title: 'layer-100/module-2',
+              },
+              {
+                id: 'PVT_000000000000003',
+                title: 'layer-100/module-3',
+              },
+              {
+                id: 'PVT_000000000000004',
+                title: 'layer-100/module-4',
+              },
+              {
+                id: 'PVT_000000000000005',
+                title: 'layer-100/module-5',
+              },
+            ],
+          },
+        }))
+
+        // final call - result of sync() method
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+              {
+                id: 'PVT_000000000000002',
+                title: 'layer-100/module-2',
+              },
+              {
+                id: 'PVT_000000000000003',
+                title: 'layer-100/module-3',
+              },
+              {
+                id: 'PVT_000000000000004',
+                title: 'layer-100/module-4',
+              },
+              {
+                id: 'PVT_000000000000005',
+                title: 'layer-100/module-5',
+              },
+            ],
+          },
+        }));
+
+      jest.spyOn(apiWrapper, 'createProject')
+        .mockImplementation(() => ('PVT_0000000000000001'));
+
+      rpm = new RepositoryProjectsManager({ apiWrapper, ownerName: 'acme', repositoryName: 'example-repository' });
+    });
+
+    test('when four projects are missing', async () => {
+      const titles = [
+        'layer-200/module-1',
+        'layer-100/module-2',
+        'layer-100/module-3',
+        'layer-100/module-4',
+        'layer-100/module-5',
+      ];
+
+      await rpm.sync(titles);
+      const outputTitles = rpm.projects().map((p) => p.title);
+      expect(outputTitles).toEqual(titles);
+    });
+  });
+
+  describe('when the number of suspicously few projects is actually correct', () => {
+    let rpm;
+
+    beforeEach(() => {
+      const apiWrapper = new ApiWrapper({ octokit: null });
+
+      jest.spyOn(apiWrapper, 'fetchOrganiztion')
+        .mockImplementation(() => ({
+          organization: {
+            id: 'O_0000000001',
+            name: 'Babbel Sandbox',
+          },
+        }));
+
+      // API returns suspiciously few projects but this is correct
+      jest.spyOn(apiWrapper, 'fetchRepository')
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+            ],
+          },
+        }))
+
+        // first retry
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+            ],
+          },
+        }))
+
+        // second retry
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+            ],
+          },
+        }))
+
+        // third retry
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+            ],
+          },
+        }))
+
+        // final call - result of sync() method
+        .mockImplementationOnce(() => ({
+          name: 'example-repository',
+          id: 'R_0000000001',
+          projectsV2: {
+            nodes: [
+              {
+                id: 'PVT_000000000000001',
+                title: 'layer-200/module-1',
+              },
+              {
+                id: 'PVT_000000000000002',
+                title: 'layer-100/module-2',
+              },
+              {
+                id: 'PVT_000000000000003',
+                title: 'layer-100/module-3',
+              },
+              {
+                id: 'PVT_000000000000004',
+                title: 'layer-100/module-4',
+              },
+              {
+                id: 'PVT_000000000000005',
+                title: 'layer-100/module-5',
+              },
+            ],
+          },
+        }));
+
+      jest.spyOn(apiWrapper, 'createProject')
+        .mockImplementation(() => ('PVT_0000000000000001'));
+
+      rpm = new RepositoryProjectsManager({ apiWrapper, ownerName: 'acme', repositoryName: 'example-repository' });
+    });
+
+    test('when four projects are missing', async () => {
+      const titles = [
+        'layer-200/module-1',
+        'layer-100/module-2',
+        'layer-100/module-3',
+        'layer-100/module-4',
+        'layer-100/module-5',
+      ];
+
+      await rpm.sync(titles);
+      const outputTitles = rpm.projects().map((p) => p.title);
+      expect(outputTitles).toEqual(titles);
+    });
+  });
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -31009,9 +31009,15 @@ const GraphQlOctokit = _octokit_core__WEBPACK_IMPORTED_MODULE_2__/* .Octokit.plu
 // for token type installation, pass only the token
 const octokit = new GraphQlOctokit({ auth: process.env.GITHUB_TOKEN });
 
+const hasDuplicates = (array) => new Set(array).size !== array.length;
+
 try {
   const projectTitlesInput = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('project-titles');
   const titles = projectTitlesInput.split(/\s+/);
+
+  if (hasDuplicates(titles)) {
+    throw new Error(`Duplicate project titles are not allowed: ${titles}`);
+  }
 
   // Get the JSON webhook payload for the event that triggered the workflow
   const {

--- a/index.js
+++ b/index.js
@@ -14,9 +14,15 @@ const GraphQlOctokit = Octokit.plugin(paginateGraphQL);
 // for token type installation, pass only the token
 const octokit = new GraphQlOctokit({ auth: process.env.GITHUB_TOKEN });
 
+const hasDuplicates = (array) => new Set(array).size !== array.length;
+
 try {
   const projectTitlesInput = core.getInput('project-titles');
   const titles = projectTitlesInput.split(/\s+/);
+
+  if (hasDuplicates(titles)) {
+    throw new Error(`Duplicate project titles are not allowed: ${titles}`);
+  }
 
   // Get the JSON webhook payload for the event that triggered the workflow
   const {

--- a/projects.js
+++ b/projects.js
@@ -66,6 +66,9 @@ class RepositoryProjectsManager {
 
     this.#projects = this.#repository.projectsV2.nodes;
 
+    // eslint-disable-next-line no-console
+    console.log(`fetched projects, run ${run}: ${JSON.stringify(this.#projects, null, 2)}`);
+
     this.#titlesToCreate = titles.filter((title) => !this.#projects.map((p) => p.title)
       .includes(title));
 
@@ -80,6 +83,9 @@ class RepositoryProjectsManager {
   }
 
   async #createMissingProjectsFrom() {
+    // eslint-disable-next-line no-console
+    console.log(`creating projects ${JSON.stringify(this.#titlesToCreate, null, 2)}`);
+
     for await (const title of this.#titlesToCreate) {
       // call synchronously because more than 5 async requests break API endpoint
       await this.#apiWrapper.createProject({
@@ -92,6 +98,9 @@ class RepositoryProjectsManager {
 
   async #deleteProjectsNotGivenBy(titles) {
     const projectsToDelete = this.#projects.filter((p) => !titles.includes(p.title));
+
+    // eslint-disable-next-line no-console
+    console.log(`deleting projects: ${JSON.stringify(projectsToDelete, null, 2)}`);
 
     for await (const project of projectsToDelete) {
       // more than 5 breaks API endpoint

--- a/projects.js
+++ b/projects.js
@@ -48,10 +48,15 @@ class RepositoryProjectsManager {
     // https://github.blog/changelog/label/deprecation/
     this.#organization = await this.#apiWrapper.fetchOrganiztion({ ownerName: this.#ownerName });
 
+    await this.#initRepositoryAndProjectsWithRetry();
+  }
+
+  async #initRepositoryAndProjectsWithRetry() {
     this.#repository = await this.#apiWrapper.fetchRepository({
       ownerName: this.#ownerName,
       repositoryName: this.#repositoryName,
     });
+
     this.#projects = this.#repository.projectsV2.nodes;
   }
 


### PR DESCRIPTION
I plan to merge this only on Monday to avoid DependaBot merges causing any unexpected issues.

This PR address an infrequent but time consuming bug: once every few weeks this GitHub action fails and results in creating duplicate GitHub Repository projects. Fixing this has to be done manually and is time consuming. Until the fix is out the review process is impeded.

The actual cause of the bug is unknown. However, we attempt to address the issue in three ways as follows.

1. reject GitHub action inputs with duplicate GitHub projects
2. if we attempt to create more than one new project, first re-try if the basis for this intention (projects fetched from API)  is correct (by fetching projects from API again). This assumes the bug comes from a broken API GET call.
3. Add more debbuging output