### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -6,6 +6,9 @@
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/babbel/sync-repository-projects/security/code-scanning/10](https://github.com/babbel/sync-repository-projects/security/code-scanning/10)

In general, the fix is to add an explicit `permissions:` block to the workflow or to the specific job so that the `GITHUB_TOKEN` has only the scopes required. For this workflow, it only needs to read repository contents (for checkout and git diff) and upload artifacts, which does not require write access to repository contents or other scopes. The minimal safe setting is `contents: read` at the workflow root, so it applies to all jobs (currently only `check-dist`).

Concretely, in `.github/workflows/check-dist.yml`, insert a `permissions:` section after the `name:` (or anywhere at the top-level before `jobs:`), e.g.:

```yaml
name: Check dist/

permissions:
  contents: read
```

No additional imports or definitions are needed, and no existing steps need to change. This will restrict the `GITHUB_TOKEN` to read-only repository contents while preserving current behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
